### PR TITLE
tax only line items with tax rates

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,5 +1,11 @@
 Spree::LineItem.class_eval do
 
+  def self.with_tax_rates
+    lis = select { |li| li.taxable? }
+
+    where(id: lis.map(&:id))
+  end
+
   def taxable?
     product.tax_category.tax_rates.any?
   end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,0 +1,6 @@
+Spree::LineItem.class_eval do
+
+  def taxable?
+    product.tax_category.tax_rates.any?
+  end
+end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -40,4 +40,12 @@ Spree::Order.class_eval do
     end
   end
 
+  def line_items_with_tax_rates
+    arr = []
+    line_items.each do |li|
+      tax_category = li.product.tax_category
+      arr << li if tax_category.tax_rates.any?
+    end
+    arr
+  end
 end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -41,11 +41,8 @@ Spree::Order.class_eval do
   end
 
   def line_items_with_tax_rates
-    arr = []
-    line_items.each do |li|
-      tax_category = li.product.tax_category
-      arr << li if tax_category.tax_rates.any?
-    end
-    arr
+    lis = line_items.select { |li| li.taxable? }
+
+    line_items.where(id: lis.map(&:id))
   end
 end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -39,10 +39,4 @@ Spree::Order.class_eval do
       update_columns(state: 'payment', updated_at: Time.now)
     end
   end
-
-  def line_items_with_tax_rates
-    lis = line_items.select { |li| li.taxable? }
-
-    line_items.where(id: lis.map(&:id))
-  end
 end

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -63,7 +63,7 @@ module SpreeAvatax::SalesShared
       tax_lines = Array.wrap(avatax_result[:tax_lines][:tax_line])
 
       # builds a hash like: {"L-111": {record: #<Spree::LineItem ...>}, ...}
-      data = (order.line_items_with_tax_rates + order.shipments).map { |r| [avatax_id(r), {record: r}] }.to_h
+      data = (order.line_items.with_tax_rates + order.shipments).map { |r| [avatax_id(r), {record: r}] }.to_h
 
       # adds :tax_line to each entry in the data
       tax_lines.each do |tax_line|
@@ -112,7 +112,7 @@ module SpreeAvatax::SalesShared
       destroyed_adjustments = order.all_adjustments.tax.destroy_all
       return if destroyed_adjustments.empty?
 
-      taxable_records = order.line_items_with_tax_rates + order.shipments
+      taxable_records = order.line_items.with_tax_rates + order.shipments
       taxable_records.each do |taxable_record|
         taxable_record.update_attributes!({
           additional_tax_total: 0,
@@ -174,7 +174,7 @@ module SpreeAvatax::SalesShared
     end
 
     def gettax_lines_params(order)
-      line_items = order.line_items_with_tax_rates.includes(variant: :product)
+      line_items = order.line_items.with_tax_rates.includes(variant: :product)
 
       line_item_lines = line_items.map do |line_item|
         {

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -63,7 +63,7 @@ module SpreeAvatax::SalesShared
       tax_lines = Array.wrap(avatax_result[:tax_lines][:tax_line])
 
       # builds a hash like: {"L-111": {record: #<Spree::LineItem ...>}, ...}
-      data = (order.line_items + order.shipments).map { |r| [avatax_id(r), {record: r}] }.to_h
+      data = (order.line_items_with_tax_rates + order.shipments).map { |r| [avatax_id(r), {record: r}] }.to_h
 
       # adds :tax_line to each entry in the data
       tax_lines.each do |tax_line|
@@ -112,7 +112,7 @@ module SpreeAvatax::SalesShared
       destroyed_adjustments = order.all_adjustments.tax.destroy_all
       return if destroyed_adjustments.empty?
 
-      taxable_records = order.line_items + order.shipments
+      taxable_records = order.line_items_with_tax_rates + order.shipments
       taxable_records.each do |taxable_record|
         taxable_record.update_attributes!({
           additional_tax_total: 0,
@@ -174,7 +174,7 @@ module SpreeAvatax::SalesShared
     end
 
     def gettax_lines_params(order)
-      line_items = order.line_items.includes(variant: :product)
+      line_items = order.line_items_with_tax_rates.includes(variant: :product)
 
       line_item_lines = line_items.map do |line_item|
         {

--- a/app/models/spree_avatax/shared.rb
+++ b/app/models/spree_avatax/shared.rb
@@ -25,7 +25,7 @@ module SpreeAvatax::Shared
     end
 
     def taxable_order?(order)
-      order.line_items.present? && order.ship_address.present?
+      order.line_items_with_tax_rates.present? && order.ship_address.present?
     end
 
     def get_tax(params)

--- a/app/models/spree_avatax/shared.rb
+++ b/app/models/spree_avatax/shared.rb
@@ -25,7 +25,7 @@ module SpreeAvatax::Shared
     end
 
     def taxable_order?(order)
-      order.line_items_with_tax_rates.present? && order.ship_address.present?
+      order.line_items.with_tax_rates.present? && order.ship_address.present?
     end
 
     def get_tax(params)


### PR DESCRIPTION
@aamyot @bryanmtl 

what do you guys think of this? Basically I'm trying to exclude any products that doesn't have any tax rates to be included on any tax calculation. 

This way, admin can create products and assign it with a tax category. But that tax category must not have any tax rates assigned to it.

cc @DanielWright 
