### PR TITLE
Accommodate Tax Adjustments with No Source

### DIFF
--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -25,7 +25,7 @@ module SpreeAvatax
       private
 
       def avatax?
-        tax? && self.source.avatax?
+        tax? && self.source && self.source.avatax?
       end
     end
   end

--- a/spec/models/spree/adjustment_spec.rb
+++ b/spec/models/spree/adjustment_spec.rb
@@ -9,6 +9,14 @@ describe Spree::Adjustment do
         adjustment.valid?
         expect(adjustment.errors[:finalized]).to include("Tax adjustments must always be finalized for Avatax")
       end
+
+      context "without a source" do
+        let(:adjustment) { build(:adjustment, finalized: false, source: nil) }
+
+        it "is valid" do
+          expect(adjustment).to be_valid
+        end
+      end
     end
 
     context "with a tax adjustment not calculated by Avatax" do


### PR DESCRIPTION
Although a tax adjustment without a source doesn't make intuitive sense, the robustness principle counsels us to be permissive in what we expect. `Spree::Adjustment#avatax?` doesn't accommodate this possibility (nor does Solidus). 

This PR proposes to tweak the behaviour to check for the presence of a source before checking whether it's an Avatax source.