### PR TITLE
Complexify Taxable Orders.

### DIFF
--- a/app/models/spree_avatax/sales_invoice.rb
+++ b/app/models/spree_avatax/sales_invoice.rb
@@ -28,7 +28,7 @@ class SpreeAvatax::SalesInvoice < ActiveRecord::Base
         return
       end
 
-      return if order.completed? || !SpreeAvatax::Shared.taxable_order?(order) || order.pos_order?
+      return if order.completed? || !SpreeAvatax::Shared.taxable_order?(order)
 
       result = SpreeAvatax::SalesShared.get_tax(order, DOC_TYPE)
       # run this immediately to ensure that everything matches up before modifying the database

--- a/app/models/spree_avatax/shared.rb
+++ b/app/models/spree_avatax/shared.rb
@@ -25,6 +25,8 @@ module SpreeAvatax::Shared
     end
 
     def taxable_order?(order)
+      return false if order.pos_order?
+      return false unless order.store.country.iso =~ /(US|CA)/
       order.line_items.present? && order.ship_address.present?
     end
 


### PR DESCRIPTION
Taxable orders is somewhat of a large item for GV2. Avalara works
wonderful when dealing with North American or USA and CA orders.
However, Solidus itself can get to the bottom of VAT oriented taxes in a
much more elegant, and 'at the application level' manner.

Make sure we only create an invoice and call out to the Avatax service if
the order is under the CA and US stores. This also includes a slight
refactoring to tuck knowledge of a POS order into this taxable_order
method.