### PR TITLE
Only Commit a Sales Invoice If Avatax Adjustments Exist

### DIFF
--- a/app/jobs/commit_sales_invoice_job.rb
+++ b/app/jobs/commit_sales_invoice_job.rb
@@ -4,7 +4,6 @@ class CommitSalesInvoiceJob < ActiveJob::Base
   def perform(order_id)
     order = ::Spree::Order.find(order_id)
     return if order.pos_order?
-    return unless order.avatax_sales_invoice
     SpreeAvatax::SalesInvoice.commit(order)
   end
 end

--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -20,6 +20,10 @@ module SpreeAvatax
             where(source_type.not_eq('Spree::TaxRate').or source_type.eq(nil))
           end
         end
+
+        base.scope :avatax, -> do
+          base.where(source_id: Spree::TaxRate.avatax.ids)
+        end
       end
 
       private

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -11,7 +11,7 @@ module SpreeAvatax
         end
 
         base.state_machine.after_transition to: :complete do |order, transition|
-          ::CommitSalesInvoiceJob.perform_later(order.id)
+          ::CommitSalesInvoiceJob.perform_later(order.id) if order.any_avatax_adjustments?
         end
 
         base.state_machine.after_transition to: :canceled do |order, transition|
@@ -37,6 +37,10 @@ module SpreeAvatax
           Rails.logger.info "[avatax] order address change detected for order #{number} while in confirm state. resetting order state to 'payment'."
           update_columns(state: 'payment', updated_at: Time.now)
         end
+      end
+
+      def any_avatax_adjustments?
+        all_adjustments.tax.avatax.any?
       end
 
       def pos_order?


### PR DESCRIPTION
The callback triggered by an order reaching the 'complete' state would attempt to commit the Avalara sales invoice, whether or not one existed, or _should_ exist. For example, an order not covered by Avatax would expect not to have an Avalara sales invoice. The effect, however, was to trigger a commit attempt, which would raise an exception.

This PR proposes to impose a condition on the attempt to commit: the presence of any Avatax
tax adjustments. This will cover all cases where the absence of a sales-invoice is expected: where other tax-rates are used, or jurisdictions in which the business does not need to collect taxes.