### PR TITLE
Skip Return Invoices When Outside of NA.

### DIFF
--- a/app/models/spree_avatax/return_invoice.rb
+++ b/app/models/spree_avatax/return_invoice.rb
@@ -31,7 +31,7 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
     # After the reimbursement completes the ".finalize" method will get called and we'll commit the
     #   return invoice.
     def generate(reimbursement)
-      if !SpreeAvatax::Config.enabled
+      if !SpreeAvatax::Config.enabled || !reimbursement.order.store.country.iso =~ /(US|CA)/
         logger.info("Avatax disabled. Skipping ReturnInvoice.generate for reimbursement #{reimbursement.number}")
         return
       end

--- a/app/models/spree_avatax/return_invoice.rb
+++ b/app/models/spree_avatax/return_invoice.rb
@@ -31,10 +31,11 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
     # After the reimbursement completes the ".finalize" method will get called and we'll commit the
     #   return invoice.
     def generate(reimbursement)
-      if !SpreeAvatax::Config.enabled || !north_american_order?(reimbursement)
+      if !SpreeAvatax::Config.enabled 
         logger.info("Avatax disabled. Skipping ReturnInvoice.generate for reimbursement #{reimbursement.number}")
         return
       end
+      return if !north_american_order?(reimbursement) || no_sales_receipt(reimbursement)
 
       success_result = get_tax(reimbursement)
 
@@ -90,6 +91,10 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
     end
 
     private
+
+    def no_sales_receipt?(reimbursement)
+      reimbursement.order.avatax_sales_invoice.nil?
+    end
 
     def north_american_order?(reimbursement)
       [1,2].include?(reimbursement.order.store_id)

--- a/app/models/spree_avatax/return_invoice.rb
+++ b/app/models/spree_avatax/return_invoice.rb
@@ -31,7 +31,7 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
     # After the reimbursement completes the ".finalize" method will get called and we'll commit the
     #   return invoice.
     def generate(reimbursement)
-      if !SpreeAvatax::Config.enabled || !reimbursement.order.store.country.iso =~ /(US|CA)/
+      if !SpreeAvatax::Config.enabled || !north_american_order?(reimbursement)
         logger.info("Avatax disabled. Skipping ReturnInvoice.generate for reimbursement #{reimbursement.number}")
         return
       end
@@ -90,6 +90,10 @@ class SpreeAvatax::ReturnInvoice < ActiveRecord::Base
     end
 
     private
+
+    def north_american_order?(reimbursement)
+      [1,2].include?(reimbursement.order.store_id)
+    end
 
     def get_tax(reimbursement)
       params = get_tax_params(reimbursement)


### PR DESCRIPTION
If an order has been placed outside of North America, we don't want to
issue a return invoice.