### PR TITLE
 Reduces Unnecessary Duplicated Sales Invoice Generation

### DIFF
--- a/app/models/spree/adjustment_decorator.rb
+++ b/app/models/spree/adjustment_decorator.rb
@@ -20,6 +20,10 @@ module SpreeAvatax
             where(source_type.not_eq('Spree::TaxRate').or source_type.eq(nil))
           end
         end
+
+        base.scope :avatax, -> do
+          base.where(source_id: Spree::TaxRate.avatax.ids)
+        end
       end
 
       private

--- a/app/models/spree/tax/order_adjuster_decorator.rb
+++ b/app/models/spree/tax/order_adjuster_decorator.rb
@@ -1,0 +1,14 @@
+module SpreeAvatax
+  module Extensions
+    module OrderAdjuster
+      def adjust!
+        return super unless rates_for_order_zone(order).all?(&:avatax?)
+
+        SpreeAvatax::SalesInvoice.generate(order)
+      end
+    end
+  end
+end
+
+::Spree::Tax::OrderAdjuster.prepend \
+  ::SpreeAvatax::Extensions::OrderAdjuster

--- a/app/models/spree/tax/order_adjuster_decorator.rb
+++ b/app/models/spree/tax/order_adjuster_decorator.rb
@@ -2,9 +2,15 @@ module SpreeAvatax
   module Extensions
     module OrderAdjuster
       def adjust!
-        return super unless rates_for_order_zone(order).all?(&:avatax?)
+        super
 
-        SpreeAvatax::SalesInvoice.generate(order)
+        SpreeAvatax::SalesInvoice.generate(order) if any_avatax_rates?
+      end
+
+      private
+
+      def any_avatax_rates?
+        rates_for_order_zone(order).any?(&:avatax?)
       end
     end
   end

--- a/app/models/spree/tax_rate_decorator.rb
+++ b/app/models/spree/tax_rate_decorator.rb
@@ -31,11 +31,9 @@ module SpreeAvatax
       end
 
       def adjust(order_tax_zone, item)
-        if self.avatax?
-          SpreeAvatax::SalesInvoice.generate(item.order)
-        else
-          super
-        end
+        return if self.avatax?
+
+        super
       end
 
       private

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -109,7 +109,7 @@ module SpreeAvatax::SalesShared
         end
       end
 
-      destroyed_adjustments = order.all_adjustments.tax.destroy_all
+      destroyed_adjustments = order.all_adjustments.avatax.destroy_all
       return if destroyed_adjustments.empty?
 
       taxable_records = order.line_items + order.shipments

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -70,6 +70,19 @@ describe Spree::Order do
       expect(SpreeAvatax::SalesInvoice).to receive(:generate).with(order).exactly(:once)
       subject.next!
     end
+
+    context "with an Avatax-calculated tax-rate and a non-Avatax-calculated tax-rate" do
+      before do
+        create(:tax_rate,
+               zone_id: subject.tax_zone.id,
+               calculator: create(:default_tax_calculator))
+      end
+
+      it "generates a sales invoice" do
+        expect(SpreeAvatax::SalesInvoice).to receive(:generate).with(order).exactly(:once)
+        subject.next!
+      end
+    end
   end
 
   context "when transitioning to payment" do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -50,6 +50,8 @@ describe Spree::Order do
   end
 
   context "when transitioning from address" do
+    let!(:order) { create(:order_with_line_items, line_items_count: 2) }
+
     before do
       subject.update_attributes!(state: 'address')
     end
@@ -65,7 +67,7 @@ describe Spree::Order do
     end
 
     it "generates a sales invoice" do
-      expect(SpreeAvatax::SalesInvoice).to receive(:generate).with(order)
+      expect(SpreeAvatax::SalesInvoice).to receive(:generate).with(order).exactly(:once)
       subject.next!
     end
   end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -89,9 +89,22 @@ describe Spree::Order do
       subject.payments.create!(state: 'checkout')
     end
 
-    it "commits the sales invoice" do
-      expect(SpreeAvatax::SalesInvoice).to receive(:commit).with(subject)
-      subject.complete!
+    context "without a sales invoice" do
+      it "doesn't commit the sales invoice" do
+        expect(SpreeAvatax::SalesInvoice).to receive(:commit).with(subject).never
+        subject.complete!
+      end
+    end
+
+    context "with a sales invoice" do
+      before do
+        subject.avatax_sales_invoice = build(:avatax_sales_invoice)
+      end
+
+      it "commits the sales invoice" do
+        expect(SpreeAvatax::SalesInvoice).to receive(:commit).with(subject)
+        subject.complete!
+      end
     end
   end
 

--- a/spec/models/spree/tax/order_adjuster_spec.rb
+++ b/spec/models/spree/tax/order_adjuster_spec.rb
@@ -8,6 +8,7 @@ describe Spree::Tax::OrderAdjuster do
     Spree::TaxRate.destroy_all
 
     create(:tax_rate, zone: avatax_zone, calculator: create(:avatax_tax_calculator))
+    create(:tax_rate, zone: avatax_zone, calculator: create(:default_tax_calculator))
     create(:tax_rate, zone: non_avatax_zone, calculator: create(:default_tax_calculator))
   end
 
@@ -36,12 +37,6 @@ describe Spree::Tax::OrderAdjuster do
 
       it "generates a sales-invoice" do
         expect(sales_invoice_klass).to receive(:generate).exactly(:once)
-
-        adjuster.adjust!
-      end
-
-      it "does not invoke the item-adjuster service" do
-        expect(item_adjuster).to receive(:adjust!).never
 
         adjuster.adjust!
       end

--- a/spec/models/spree/tax/order_adjuster_spec.rb
+++ b/spec/models/spree/tax/order_adjuster_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe Spree::Tax::OrderAdjuster do
+  let!(:avatax_zone) { create(:zone, :with_country) }
+  let!(:non_avatax_zone) { create(:zone, :with_country) }
+
+  before do
+    Spree::TaxRate.destroy_all
+
+    create(:tax_rate, zone: avatax_zone, calculator: create(:avatax_tax_calculator))
+    create(:tax_rate, zone: non_avatax_zone, calculator: create(:default_tax_calculator))
+  end
+
+  describe "#adjust!" do
+    let(:item_adjuster_klass) { double(:item_adjuster_klass) }
+    let(:item_adjuster) { double(:item_adjuster) }
+    let(:sales_invoice_klass) { double(:sales_invoice_klass) }
+
+    let(:order) { create(:order_ready_to_complete) }
+
+    subject(:adjuster) { described_class.new(order) }
+
+    before do
+      stub_const("SpreeAvatax::SalesInvoice", sales_invoice_klass)
+      allow(item_adjuster_klass).to receive(:new).and_return(item_adjuster)
+      allow(item_adjuster).to receive(:adjust!)
+
+      stub_const("Spree::Tax::ItemAdjuster", item_adjuster_klass)
+      allow(sales_invoice_klass).to receive(:generate)
+    end
+
+    context "with an order in an Avatax-calculated zone" do
+      before do
+        allow(order).to receive(:tax_zone).and_return(avatax_zone)
+      end
+
+      it "generates a sales-invoice" do
+        expect(sales_invoice_klass).to receive(:generate).exactly(:once)
+
+        adjuster.adjust!
+      end
+
+      it "does not invoke the item-adjuster service" do
+        expect(item_adjuster).to receive(:adjust!).never
+
+        adjuster.adjust!
+      end
+    end
+
+    context "with an order not in an Avatax-calculated zone" do
+      before do
+        allow(order).to receive(:tax_zone).and_return(non_avatax_zone)
+      end
+
+      it "doesn't generate a sales-invoice in Avalara" do
+        expect(sales_invoice_klass).to receive(:generate).never
+
+        adjuster.adjust!
+      end
+
+      it "invokes the item-adjuster service" do
+        expect(item_adjuster).to receive(:adjust!).at_least(:once)
+
+        adjuster.adjust!
+      end
+    end
+  end
+end

--- a/spec/models/spree_avatax/return_invoice_spec.rb
+++ b/spec/models/spree_avatax/return_invoice_spec.rb
@@ -67,6 +67,11 @@ describe SpreeAvatax::ReturnInvoice do
       SpreeAvatax::ReturnInvoice.generate(reimbursement)
     end
 
+    before do
+      allow(order).to receive(:store_id).and_return(1)
+      allow(order).to receive(:avatax_sales_invoice).and_return(double)
+    end
+
     it 'creates a return invoice' do
       expect {
         subject
@@ -192,6 +197,10 @@ describe SpreeAvatax::ReturnInvoice do
 
     subject do
       SpreeAvatax::ReturnInvoice.finalize(return_invoice.reimbursement)
+    end
+
+    before do
+      create(:avatax_sales_invoice, order: return_invoice.reimbursement.order)
     end
 
     it 'marks the return invoice as committed' do

--- a/spec/models/spree_avatax/short_ship_return_invoice_spec.rb
+++ b/spec/models/spree_avatax/short_ship_return_invoice_spec.rb
@@ -93,7 +93,7 @@ describe SpreeAvatax::ShortShipReturnInvoice do
 
               taxoverridetypeline: SpreeAvatax::ShortShipReturnInvoice::TAX_OVERRIDE_TYPE,
               reasonline:          SpreeAvatax::ShortShipReturnInvoice::TAX_OVERRIDE_REASON,
-              taxamountline:       -1.to_d,
+              taxamountline:       0.to_d,
               taxdateline:         now.to_date,
 
               description: REXML::Text.normalize(inventory_unit_1.line_item.variant.product.description[0...100]),

--- a/spec/models/spree_avatax/short_ship_return_invoice_spec.rb
+++ b/spec/models/spree_avatax/short_ship_return_invoice_spec.rb
@@ -93,7 +93,7 @@ describe SpreeAvatax::ShortShipReturnInvoice do
 
               taxoverridetypeline: SpreeAvatax::ShortShipReturnInvoice::TAX_OVERRIDE_TYPE,
               reasonline:          SpreeAvatax::ShortShipReturnInvoice::TAX_OVERRIDE_REASON,
-              taxamountline:       0.to_d,
+              taxamountline:       -1.to_d,
               taxdateline:         now.to_date,
 
               description: REXML::Text.normalize(inventory_unit_1.line_item.variant.product.description[0...100]),


### PR DESCRIPTION
An Avatax sales invoice doesn't need to be generated each time tax-adjustment is calculated for a single line-item or shipment.  Once per order is just fine, thankyouverymuch. This PR proposes a change of this behaviour by overriding `Spree::Tax::OrderAdjuster#adjust!`.  When all the tax-rates for the order's zone are Avatax-calculated, the entire order is adjusted by the `SalesInvoice.generate` call, a sales invoice is generated, and the item-by-item adjustment phase is short-circuited. Without any Avatax-calculated rates, the normal item-by-item adjustment phase proceeds as before.

As a result, `TaxRate#adjust` is once again a no-op when the tax-rate is Avatax-calculated.

Finally, a number of failing specs have been fixed.