### PR TITLE
(FC) Change customer code from email to order number

### DIFF
--- a/app/models/spree_avatax/config.rb
+++ b/app/models/spree_avatax/config.rb
@@ -2,8 +2,6 @@ module SpreeAvatax
   class Config < Spree::Base
     DEFAULT_TIMEOUT = 20
 
-    class Exception < RuntimeError; end
-
     class << self
       attr_accessor :username
       attr_accessor :password
@@ -32,9 +30,8 @@ module SpreeAvatax
       end
 
       def customer_code=(evaluator)
-        raise(Exception) unless evaluator.respond_to?(:call)
-
-        @customer_code = evaluator
+        @customer_code = evaluator.respond_to?(:call) \
+          && evaluator || ->(_) { evaluator }
       end
 
       private

--- a/app/models/spree_avatax/config.rb
+++ b/app/models/spree_avatax/config.rb
@@ -2,6 +2,8 @@ module SpreeAvatax
   class Config < Spree::Base
     DEFAULT_TIMEOUT = 20
 
+    class Exception < RuntimeError; end
+
     class << self
       attr_accessor :username
       attr_accessor :password
@@ -25,10 +27,24 @@ module SpreeAvatax
         (config = active) ? config.enabled : true
       end
 
+      def customer_code
+        @customer_code || default_customer_code
+      end
+
+      def customer_code=(evaluator)
+        raise(Exception) unless evaluator.respond_to?(:call)
+
+        @customer_code = evaluator
+      end
+
       private
 
       def active
         order(:id).last
+      end
+
+      def default_customer_code
+        ->(order) { order.email }
       end
     end
 

--- a/app/models/spree_avatax/sales_shared.rb
+++ b/app/models/spree_avatax/sales_shared.rb
@@ -142,10 +142,12 @@ module SpreeAvatax::SalesShared
 
     # see https://github.com/avadev/AvaTax-Calc-SOAP-Ruby/blob/master/GetTaxTest.rb
     def gettax_params(order, doc_type)
+      config = SpreeAvatax::Config
+
       {
         doccode:       order.number,
-        customercode:  REXML::Text.normalize(order.email),
-        companycode:   SpreeAvatax::Config.company_code,
+        customercode:  REXML::Text.normalize(config.customer_code.call(order)),
+        companycode:   config.company_code,
 
         doctype: doc_type,
         docdate: Date.today,

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -99,7 +99,7 @@ describe Spree::Order do
   context "when transitioning to complete" do
     before do
       subject.update_attributes!(state: 'confirm')
-      subject.payments.create!(state: 'checkout')
+      create(:payment, order: order)
     end
 
     context "without a sales invoice" do

--- a/spec/models/spree_avatax/config_spec.rb
+++ b/spec/models/spree_avatax/config_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe SpreeAvatax::Config do
       expect(order).to have_received(:email)
     end
 
-    it 'is be configured' do
+    it 'can be configured with a proc' do
       described_class.customer_code = ->(order) { order.number }
       described_class.customer_code.call(order)
 
       expect(order).to have_received(:number)
     end
 
-    it 'raises an exception if misconfigured' do
-      expect { described_class.customer_code = 'HARDCODED' }
-        .to raise_error SpreeAvatax::Config::Exception
+    it 'can be configured with a value' do
+      described_class.customer_code = 'value'
+      expect(described_class.customer_code.call(order)).to eq 'value'
     end
   end
 end

--- a/spec/models/spree_avatax/config_spec.rb
+++ b/spec/models/spree_avatax/config_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe SpreeAvatax::Config do
+  describe 'customer_code configuration' do
+    let(:order) { spy(:order) }
+
+    after do
+      described_class.customer_code = \
+        described_class.send(:default_customer_code)
+    end
+
+    it 'has a sane default' do
+      described_class.customer_code.call(order)
+
+      expect(order).to have_received(:email)
+    end
+
+    it 'is be configured' do
+      described_class.customer_code = ->(order) { order.number }
+      described_class.customer_code.call(order)
+
+      expect(order).to have_received(:number)
+    end
+
+    it 'raises an exception if misconfigured' do
+      expect { described_class.customer_code = 'HARDCODED' }
+        .to raise_error SpreeAvatax::Config::Exception
+    end
+  end
+end


### PR DESCRIPTION
Here's the [clubhouse card](https://app.clubhouse.io/glossier-dot-com/story/13834/as-a-guest-shopper-i-want-to-be-able-to-use-fc-so-i-can-check-out-as-quickly-as-possible) that has more information about this

Reiterating what I said in a specific commit for context:

```
This change is motivated by a hard to work around flow during ApplePay
checkout flow where we only get the customer's information like their
email at the very end step.

Switching from email to order number still affords us to derive the
customer's information by going from the order to the order's email or
the order's customer and then the email or even addresses.
```